### PR TITLE
Add AI Solution Center & Freshdesk integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@
 LLM_API_KEY=YOUR_LLM_API_KEY_HERE
 LLM_API_ENDPOINT=https://api.openai.com/v1/chat/completions # Example for OpenAI
 LLM_MODEL=gpt-4o # Or your preferred model
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+ELEVENLABS_API_KEY=
+FRESHDESK_DOMAIN=
+FRESHDESK_API_KEY=
 
 # Database Path (Optional, defaults to network_traffic.db in the same directory)
 # DB_PATH=data/network_traffic.db

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A Streamlit-based dashboard for real-time network traffic monitoring, analysis, 
 *   **Data Management:** Options to optimize the database, clean up old data, and reset the dashboard.
 *   **Memory Management:** Monitors RAM usage and performs cleanup actions to prevent crashes.
 *   **Configurable:** Settings managed via environment variables (`.env` file).
+*   **AI Solution Center:** Chat in real time with multiple providers (OpenAI, Anthropic Claude, Google Gemini) and optional ElevenLabs voice output.
+*   **Freshdesk Integration:** View latest support tickets directly in the dashboard with automatic refresh.
 
 
 ## Requirements
@@ -59,6 +61,9 @@ A Streamlit-based dashboard for real-time network traffic monitoring, analysis, 
     *   Edit the `.env` file with your settings:
         *   **`LLM_API_KEY` (Optional):** Add your API key if you want to use the LLM-based security insights.
         *   **`LLM_API_ENDPOINT` & `LLM_MODEL` (Optional):** Adjust if using a different LLM provider or model.
+        *   **`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` (Optional):** API keys for the AI Solution Center providers.
+        *   **`ELEVENLABS_API_KEY` (Optional):** Enable voice responses in the AI Solution Center.
+        *   **`FRESHDESK_DOMAIN` & `FRESHDESK_API_KEY` (Optional):** Configure Freshdesk ticket integration.
         *   Other settings (DB path, memory limits, etc.) can be adjusted if needed, otherwise defaults will be used.
     *   **IMPORTANT:** Never commit your `.env` file to version control. It's included in `.gitignore`.
 
@@ -80,6 +85,9 @@ A Streamlit-based dashboard for real-time network traffic monitoring, analysis, 
 Most configuration is handled via the `.env` file (see `Installation` step 4 and `.env.example`). Key options include:
 
 *   `LLM_API_KEY`, `LLM_API_ENDPOINT`, `LLM_MODEL`: For LLM integration.
+*   `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`: Keys for the AI Solution Center providers.
+*   `ELEVENLABS_API_KEY`: Enable voice output for AI responses.
+*   `FRESHDESK_DOMAIN`, `FRESHDESK_API_KEY`: Freshdesk ticket integration.
 *   `DB_PATH`: Location to store the traffic database.
 *   `MEMORY_WARNING_THRESHOLD`, `MEMORY_CRITICAL_THRESHOLD`: RAM usage thresholds for warnings and cleanup.
 *   `AUTO_CLEANUP_DAYS`: How long to retain packet data.

--- a/ai_solution_center.py
+++ b/ai_solution_center.py
@@ -1,0 +1,140 @@
+import requests
+import streamlit as st
+from typing import List, Dict
+
+import config
+
+# ---- AI Provider Helpers ----
+
+def call_openai(messages: List[Dict[str, str]]) -> str:
+    api_key = config.OPENAI_API_KEY
+    if not api_key:
+        return "OpenAI API key not configured"
+    response = requests.post(
+        config.LLM_API_ENDPOINT,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"model": config.LLM_MODEL, "messages": messages, "temperature": 0.3},
+        timeout=15,
+    )
+    if response.status_code == 200:
+        data = response.json()
+        return data.get("choices", [{}])[0].get("message", {}).get("content", "")
+    return f"Error {response.status_code}: {response.text}"
+
+def call_anthropic(messages: List[Dict[str, str]]) -> str:
+    api_key = config.ANTHROPIC_API_KEY
+    if not api_key:
+        return "Anthropic API key not configured"
+    endpoint = "https://api.anthropic.com/v1/messages"
+    response = requests.post(
+        endpoint,
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "Content-Type": "application/json",
+        },
+        json={"model": "claude-3-haiku-20240307", "messages": messages, "max_tokens": 512},
+        timeout=15,
+    )
+    if response.status_code == 200:
+        data = response.json()
+        return data.get("content", [{}])[0].get("text", "")
+    return f"Error {response.status_code}: {response.text}"
+
+def call_gemini(messages: List[Dict[str, str]]) -> str:
+    api_key = config.GEMINI_API_KEY
+    if not api_key:
+        return "Gemini API key not configured"
+    endpoint = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key={api_key}"
+    response = requests.post(
+        endpoint,
+        json={"contents": [{"parts": [{"text": m["content"]} for m in messages]}]},
+        timeout=15,
+    )
+    if response.status_code == 200:
+        data = response.json()
+        return data.get("candidates", [{}])[0].get("content", {}).get("parts", [{}])[0].get("text", "")
+    return f"Error {response.status_code}: {response.text}"
+
+# ---- ElevenLabs Text-to-Speech ----
+
+def text_to_speech(text: str) -> bytes:
+    api_key = config.ELEVENLABS_API_KEY
+    if not api_key:
+        return b""
+    url = "https://api.elevenlabs.io/v1/text-to-speech/eleven_monolingual_v1"
+    response = requests.post(
+        url,
+        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
+        json={"text": text},
+        timeout=15,
+    )
+    if response.status_code == 200:
+        return response.content
+    return b""
+
+# ---- Freshdesk Integration ----
+
+def get_freshdesk_tickets() -> List[Dict[str, str]]:
+    if not config.FRESHDESK_DOMAIN or not config.FRESHDESK_API_KEY:
+        return []
+    url = f"https://{config.FRESHDESK_DOMAIN}.freshdesk.com/api/v2/tickets?include=description"
+    try:
+        response = requests.get(url, auth=(config.FRESHDESK_API_KEY, "X"), timeout=10)
+        if response.status_code == 200:
+            return response.json()
+    except Exception:
+        pass
+    return []
+
+# ---- Streamlit View ----
+
+def display_ai_solution_center() -> None:
+    st.header("AI Solution Center")
+
+    provider = st.selectbox("AI Provider", ["OpenAI", "Anthropic Claude", "Google Gemini"])
+
+    if "ai_chat_history" not in st.session_state:
+        st.session_state.ai_chat_history = []
+
+    user_input = st.text_area("Your message", key="ai_message")
+    if st.button("Send", key="send_ai_message") and user_input:
+        st.session_state.ai_chat_history.append({"role": "user", "content": user_input})
+        if provider == "OpenAI":
+            reply = call_openai(st.session_state.ai_chat_history)
+        elif provider == "Anthropic Claude":
+            reply = call_anthropic(st.session_state.ai_chat_history)
+        else:
+            reply = call_gemini(st.session_state.ai_chat_history)
+        st.session_state.ai_chat_history.append({"role": "assistant", "content": reply})
+
+    for msg in st.session_state.ai_chat_history:
+        role = msg["role"]
+        if role == "user":
+            st.markdown(f"**You:** {msg['content']}")
+        else:
+            st.markdown(f"**AI:** {msg['content']}")
+            audio = text_to_speech(msg["content"])
+            if audio:
+                st.audio(audio, format="audio/mp3")
+
+    st.markdown("---")
+    st.subheader("Freshdesk Tickets")
+
+    # Refresh ticket list every 10 seconds
+    from streamlit_autorefresh import st_autorefresh
+    st_autorefresh(interval=10_000, key="freshdesk_refresh")
+
+    if "freshdesk_tickets" not in st.session_state:
+        st.session_state.freshdesk_tickets = get_freshdesk_tickets()
+    else:
+        # Update tickets on each refresh
+        st.session_state.freshdesk_tickets = get_freshdesk_tickets()
+
+    tickets = st.session_state.freshdesk_tickets
+    if tickets:
+        for ticket in tickets:
+            with st.expander(f"#{ticket.get('id')} - {ticket.get('subject')}"):
+                st.markdown(ticket.get('description_text', 'No description'))
+    else:
+        st.info("No tickets found or Freshdesk not configured.")

--- a/config.py
+++ b/config.py
@@ -1,0 +1,36 @@
+import os
+from dotenv import load_dotenv
+import logging
+
+# Load environment variables from .env file if present
+load_dotenv()
+
+# Basic logger setup
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Database configuration
+DB_PATH = os.getenv('DB_PATH', 'network_traffic.db')
+
+# Refresh settings
+AUTO_REFRESH_DEFAULT = os.getenv('AUTO_REFRESH_DEFAULT', 'True') == 'True'
+REFRESH_INTERVAL_DEFAULT = int(os.getenv('REFRESH_INTERVAL_DEFAULT', '10'))
+DEFAULT_TIMEFRAME = os.getenv('DEFAULT_TIMEFRAME', 'day')
+
+# Memory management
+MEMORY_WARNING_THRESHOLD = int(os.getenv('MEMORY_WARNING_THRESHOLD', '70'))
+MEMORY_CRITICAL_THRESHOLD = int(os.getenv('MEMORY_CRITICAL_THRESHOLD', '85'))
+MEMORY_CHECK_INTERVAL = int(os.getenv('MEMORY_CHECK_INTERVAL', '300'))
+
+# LLM / AI API keys
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', os.getenv('LLM_API_KEY'))
+ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')
+GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
+ELEVENLABS_API_KEY = os.getenv('ELEVENLABS_API_KEY')
+
+LLM_API_ENDPOINT = os.getenv('LLM_API_ENDPOINT', 'https://api.openai.com/v1/chat/completions')
+LLM_MODEL = os.getenv('LLM_MODEL', 'gpt-4o')
+
+# Freshdesk configuration
+FRESHDESK_DOMAIN = os.getenv('FRESHDESK_DOMAIN')
+FRESHDESK_API_KEY = os.getenv('FRESHDESK_API_KEY')

--- a/dashboard.py
+++ b/dashboard.py
@@ -23,6 +23,7 @@ from dashboard_views import (
     # Note: visualizations module functions are typically called *within*
     # the dashboard_views functions, so direct import here might not be needed.
 )
+from ai_solution_center import display_ai_solution_center
 from config import (
     logger, DB_PATH, AUTO_REFRESH_DEFAULT,
     REFRESH_INTERVAL_DEFAULT, DEFAULT_TIMEFRAME,
@@ -318,7 +319,7 @@ def main() -> None:
 
         # View selection
         st.subheader("View Selection")
-        view_options = ["Dashboard", "Network Graph", "Top Talkers", "Trend Analysis", "Security Insights"]
+        view_options = ["Dashboard", "Network Graph", "Top Talkers", "Trend Analysis", "Security Insights", "AI Solution Center"]
         current_view_index = view_options.index(st.session_state.selected_view) if st.session_state.selected_view in view_options else 0
         selected_view = st.radio(
             "Select view:",
@@ -443,6 +444,8 @@ def main() -> None:
         display_trend_analysis_view()
     elif st.session_state.selected_view == "Security Insights":
         display_security_insights_view()
+    elif st.session_state.selected_view == "AI Solution Center":
+        display_ai_solution_center()
     else:
         # Fallback if view state is somehow invalid
         st.error(f"Invalid view selected: {st.session_state.selected_view}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scapy
 python-dotenv
 psutil
 requests # Added for llm_analyzer API calls
+streamlit-autorefresh


### PR DESCRIPTION
## Summary
- add a `config.py` helper to load environment vars
- implement an AI solution center with OpenAI, Anthropic Claude, Gemini and ElevenLabs support
- integrate Freshdesk ticket viewer with auto refresh
- update dashboard to include the new view
- document new settings and feature in README
- update `.env.example` and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840554d2b50832eb27038611323d342