### PR TITLE
Add AI Solution Center view with Freshdesk search

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -19,6 +19,7 @@ from dashboard_views import (
     display_top_talkers_view,
     display_trend_analysis_view,
     display_security_insights_view,
+    display_ai_solution_center_view,
     reset_cache
     # Note: visualizations module functions are typically called *within*
     # the dashboard_views functions, so direct import here might not be needed.
@@ -274,6 +275,7 @@ def main() -> None:
         "Top Talkers",
         "Trend Analysis",
         "Security Insights",
+        "AI Solution Center",
     ]
 
     # Ensure tab index persists across reruns and sync with selected_view
@@ -523,6 +525,10 @@ def main() -> None:
     with tabs[4]:
         if selected_index == 4:
             display_security_insights_view()
+
+    with tabs[5]:
+        if selected_index == 5:
+            display_ai_solution_center_view()
 
     # --- Auto Refresh Logic ---
     if st.session_state.auto_refresh:

--- a/dashboard_views.py
+++ b/dashboard_views.py
@@ -487,3 +487,22 @@ def display_security_insights_view() -> None:
                     st.dataframe(dest_df, use_container_width=True)
         else:
             st.info("No detailed statistics available.")
+
+def display_ai_solution_center_view() -> None:
+    """Display AI Solution Center with Freshdesk search."""
+    st.header("AI Solution Center")
+
+    query = st.text_input("Search Freshdesk articles:")
+    if query:
+        with st.spinner("Searching Freshdesk..."):
+            from solution_center import search_articles
+            results = search_articles(query)
+            if isinstance(results, dict) and results.get("error"):
+                st.error(results["error"])
+            elif results:
+                for article in results:
+                    title = article.get("title", "Untitled")
+                    url = article.get("url", "#")
+                    st.markdown(f"- [{title}]({url})")
+            else:
+                st.info("No articles found.")

--- a/solution_center.py
+++ b/solution_center.py
@@ -1,0 +1,22 @@
+import os
+import requests
+
+FRESHDESK_DOMAIN = os.getenv("FRESHDESK_DOMAIN")
+FRESHDESK_API_KEY = os.getenv("FRESHDESK_API_KEY")
+
+BASE_URL = f"https://{FRESHDESK_DOMAIN}.freshdesk.com/api/v2" if FRESHDESK_DOMAIN else None
+
+
+def search_articles(query: str, per_page: int = 5):
+    """Search Freshdesk knowledge base articles."""
+    if not BASE_URL or not FRESHDESK_API_KEY:
+        return {"error": "Freshdesk credentials not configured"}
+
+    endpoint = f"{BASE_URL}/solutions/articles/search?term={query}&per_page={per_page}"
+    try:
+        resp = requests.get(endpoint, auth=(FRESHDESK_API_KEY, "X"))
+        if resp.status_code == 200:
+            return resp.json().get("results", [])
+        return {"error": f"API request failed with status {resp.status_code}"}
+    except requests.RequestException as e:
+        return {"error": str(e)}


### PR DESCRIPTION
## Summary
- introduce `solution_center.py` for Freshdesk API requests
- add new `display_ai_solution_center_view` in `dashboard_views.py`
- add AI Solution Center tab in `dashboard.py`

## Testing
- `python -m py_compile dashboard.py dashboard_views.py solution_center.py`

------
https://chatgpt.com/codex/tasks/task_e_6840570044e0832ea37ede40a59c6c60